### PR TITLE
Update for mime type standard

### DIFF
--- a/src/core/app/file.lisp
+++ b/src/core/app/file.lisp
@@ -91,7 +91,7 @@
                        (get-universal-time))))
     (when (text-file-p content-type)
       (setf content-type
-            (format nil "~A ;charset=~A"
+            (format nil "~A;charset=~A"
                     content-type encoding)))
     (with-open-file (stream file
                      :direction :input


### PR DESCRIPTION
IE9 can't get css file for nonstandard mime type.
