### PR TITLE
Allow to use chunked encoding with Hunchentoot

### DIFF
--- a/src/core/handler/hunchentoot.lisp
+++ b/src/core/handler/hunchentoot.lisp
@@ -69,12 +69,14 @@ before passing to Hunchentoot."
        (loop for k being the hash-keys in hash
              using (hash-value v)
              do (setf (header-out k) v)))
-    (etypecase body
-      (pathname
-       (hunchentoot:handle-static-file body (getf headers :content-type)))
-      (list
-       (with-output-to-string (s)
-         (format s "~{~A~^~%~}" body))))))
+    (if (string-equal (getf headers :transfer-encoding) "chunked")
+        (funcall body (send-headers))
+        (etypecase body
+          (pathname
+           (hunchentoot:handle-static-file body (getf headers :content-type)))
+          (list
+           (with-output-to-string (s)
+             (format s "~{~A~^~%~}" body)))))))
 
 (defun cookie->plist (cookie)
   "Convert Hunchentoot's cookie class into just a plist."


### PR DESCRIPTION
This allows to use chunked encoding with Hunchentoot if a function is provided
as the body value of the reply, and if the header Transfer-Encoding is set to
chunked. The function is then called with the output stream as argument.
