### PR TITLE
Fix JSON middleware to recognize Content-Type that specifies a charset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.x86f
 *.fas
 *.lib
+
+# editor backup/temp files
+*~

--- a/src/core/middleware/json.lisp
+++ b/src/core/middleware/json.lisp
@@ -23,7 +23,10 @@
   ())
 
 (defmethod call ((this <clack-middleware-json>) env)
-  (when (string-equal (getf env :content-type) "application/json")
+  (when (= (search "application/json"
+		   (getf env :content-type)
+		   :test #'equalp)
+	   0)
     (setf (getf env :body-parameters)
           (list :json (yason:parse (ensure-character-input-stream
                                     (getf env :raw-body))))))


### PR DESCRIPTION
Fix JSON middleware to recognize Content-Type that specifies a charset (e.g. "application/json; charset=UTF-8")
