### PR TITLE
Fix crashing when no Content-Type given

### DIFF
--- a/src/core/middleware/json.lisp
+++ b/src/core/middleware/json.lisp
@@ -23,8 +23,8 @@
   ())
 
 (defmethod call ((this <clack-middleware-json>) env)
-  (when (eq (search "application/json" (getf env :content-type) :test #'equalp)
-	    0)
+  (when (eql (search "application/json" (getf env :content-type) :test #'equalp)
+	     0)
     (setf (getf env :body-parameters)
           (list :json (yason:parse (ensure-character-input-stream
                                     (getf env :raw-body))))))


### PR DESCRIPTION
Sorry, I guess I messed things up with my last patch. Here is the fix.
