### PR TITLE
Two fixes in the Basic Auth middleware

### DIFF
--- a/src/contrib/middleware/auth/basic.lisp
+++ b/src/contrib/middleware/auth/basic.lisp
@@ -9,8 +9,7 @@
 (in-package :cl-user)
 (defpackage clack.middleware.auth.basic
   (:use :cl
-        :clack
-        :split-sequence)
+        :clack)
   (:import-from :cl-ppcre
                 :scan-to-strings)
   (:import-from :cl-base64
@@ -67,7 +66,9 @@
         (nth-value 1 (scan-to-strings "^Basic (.*)$" it))
         (aref it 0)
         (base64:base64-string-to-string it)
-        (split-sequence #\: it)))
+        (cons (scan-to-strings "[^:]+" it)
+              (coerce (nth-value 1 (scan-to-strings ":(.+)" it))
+                      'list))))
 
 (doc:start)
 


### PR DESCRIPTION
The first commit updates the middleware to access the new hash table representation of HTTP headers. The second commit is a bugfix for when passwords contain one or more `:` characters.

When `parse-user-and-pass` used `split-sequence` and the password contained colons the `destructuring-bind` in the `call` method failed with the wrong arity. Colons are allowed in passwords but not userids as per [RFC 2617](https://tools.ietf.org/html/rfc2617#section-2).
