### PR TITLE
This allows important Hunchentoot performance params to be used

### DIFF
--- a/src/core/clack.lisp
+++ b/src/core/clack.lisp
@@ -99,6 +99,7 @@ Example:
                         app)
                     :port port
                     :debug debug
+                    :allow-other-keys t
                     (delete-from-plist args :server :port :debug :watch
                                             :use-thread
                                             :use-cl-debugger

--- a/src/core/handler/hunchentoot.lisp
+++ b/src/core/handler/hunchentoot.lisp
@@ -35,7 +35,8 @@
 
 @export
 (defun run (app &key debug (port 5000)
-                  ssl ssl-key-file ssl-cert-file ssl-key-password)
+                  ssl ssl-key-file ssl-cert-file ssl-key-password
+                  max-thread-count max-accept-count)
   "Start Hunchentoot server."
   (initialize)
   (setf *dispatch-table*
@@ -54,19 +55,38 @@
                               (error (error)
                                 (princ error *error-output*)
                                 '(500 () ("Internal Server Error")))))))))))))
-  (let ((acceptor
+  (let* ((taskmaster (when (and max-thread-count max-accept-count)
+                       (make-instance 'one-thread-per-connection-taskmaster
+                                      :max-thread-count max-thread-count
+                                      :max-accept-count max-accept-count)))
+         (acceptor
           (if ssl
-              (make-instance 'easy-ssl-acceptor
-                             :port port
-                             :ssl-certificate-file ssl-cert-file
-                             :ssl-privatekey-file ssl-key-file
-                             :ssl-privatekey-password ssl-key-password
-                             :access-log-destination nil
-                             :error-template-directory nil)
-              (make-instance 'easy-acceptor
-                             :port port
-                             :access-log-destination nil
-                             :error-template-directory nil))))
+              (if (and max-thread-count max-accept-count)
+                  (make-instance 'easy-ssl-acceptor
+                                 :port port
+                                 :ssl-certificate-file ssl-cert-file
+                                 :ssl-privatekey-file ssl-key-file
+                                 :ssl-privatekey-password ssl-key-password
+                                 :access-log-destination nil
+                                 :error-template-directory nil
+                                 :taskmaster taskmaster)
+                  (make-instance 'easy-ssl-acceptor
+                                 :port port
+                                 :ssl-certificate-file ssl-cert-file
+                                 :ssl-privatekey-file ssl-key-file
+                                 :ssl-privatekey-password ssl-key-password
+                                 :access-log-destination nil
+                                 :error-template-directory nil))
+              (if (and max-thread-count max-accept-count)
+                  (make-instance 'easy-acceptor
+                                 :port port
+                                 :access-log-destination nil
+                                 :error-template-directory nil
+                                 :taskmaster taskmaster)
+                  (make-instance 'easy-acceptor
+                                 :port port
+                                 :access-log-destination nil
+                                 :error-template-directory nil)))))
     (setf (acceptor-shutdown-p acceptor) nil)
     (start-listening acceptor)
     (let ((taskmaster (acceptor-taskmaster acceptor)))

--- a/src/core/handler/hunchentoot.lisp
+++ b/src/core/handler/hunchentoot.lisp
@@ -36,7 +36,7 @@
 @export
 (defun run (app &key debug (port 5000)
                   ssl ssl-key-file ssl-cert-file ssl-key-password
-                  max-thread-count max-accept-count)
+                  max-thread-count max-accept-count (persistent-connections-p t))
   "Start Hunchentoot server."
   (initialize)
   (setf *dispatch-table*
@@ -69,6 +69,7 @@
                                  :ssl-privatekey-password ssl-key-password
                                  :access-log-destination nil
                                  :error-template-directory nil
+                                 :persistent-connections-p persistent-connections-p
                                  :taskmaster taskmaster)
                   (make-instance 'easy-ssl-acceptor
                                  :port port
@@ -76,17 +77,20 @@
                                  :ssl-privatekey-file ssl-key-file
                                  :ssl-privatekey-password ssl-key-password
                                  :access-log-destination nil
-                                 :error-template-directory nil))
+                                 :error-template-directory nil
+                                 :persistent-connections-p persistent-connections-p))
               (if (and max-thread-count max-accept-count)
                   (make-instance 'easy-acceptor
                                  :port port
                                  :access-log-destination nil
                                  :error-template-directory nil
+                                 :persistent-connections-p persistent-connections-p
                                  :taskmaster taskmaster)
                   (make-instance 'easy-acceptor
                                  :port port
                                  :access-log-destination nil
-                                 :error-template-directory nil)))))
+                                 :error-template-directory nil
+                                 :persistent-connections-p persistent-connections-p)))))
     (setf (acceptor-shutdown-p acceptor) nil)
     (start-listening acceptor)
     (let ((taskmaster (acceptor-taskmaster acceptor)))
@@ -189,7 +193,7 @@ Clack.Handler.Hunchentoot - Clack handler for Hunchentoot.
       (:use :cl
             :clack.handler.hunchentoot))
     (in-package :clack-sample)
-    
+
     ;; Start Server
     (run (lambda (env)
            '(200 nil (\"ok\")))


### PR DESCRIPTION
On my production site, I normally have close to 1000 users hitting the site at a time at a minimum of once every 30 seconds (it is streaming real time text data) - this causes the Hunchentoot default thread limit of 100 to be used up rather quickly.

I also believe there may be an issue with persistent connections when running clack/hunchentoot behind an apache proxy (I'm not sure if they are closing properly when the web visitor is done with them).

Allowing these Hunchentoot flags to be passed in the clackup call (or caveman2 #'start call) resolves the issues.