### PR TITLE
Change the API of Clack.Middleware.Accesslog

### DIFF
--- a/clack.asd
+++ b/clack.asd
@@ -40,8 +40,7 @@
                :marshal
                :trivial-mimes
                :trivial-backtrace
-               :bordeaux-threads
-               :log4cl)
+               :bordeaux-threads)
   :components ((:module "src"
                 :components
                 ((:module "core"


### PR DESCRIPTION
* Delete a dependency on Log4CL (refs #74).
* Make it faster by not calling 'eval'.
* Providing more common way to log.

If still you wanna use Log4CL for logging, you can specify a lambda calling log:trace.

```
(builder
  (<clack-middleware-accesslog> :logger (lambda (output) (log:trace output)))
  *app*)
```