### PR TITLE
fix t-clack-handler-wookie

### DIFF
--- a/t-clack-handler-wookie.asd
+++ b/t-clack-handler-wookie.asd
@@ -11,4 +11,4 @@
   ((:test-file "t/core/handler/wookie"))
   :defsystem-depends-on (:prove-asdf)
   :perform (test-op :after (op c)
-                    (funcall #.(intern (string :run-test-system) :prove) c)))
+                    (funcall (intern #.(string :run-test-system) :prove) c)))


### PR DESCRIPTION
```
-                    (funcall #.(intern (string :run-test-system) :prove) c)))
+                    (funcall (intern #.(string :run-test-system) :prove) c)))
```