### PR TITLE
[WIP] Fix multiple Set-Cookie headers behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   matrix:
     - LISP=sbcl
     - LISP=ccl
-    - LISP=clisp
 
 before_install:
   # libuv for Wookie

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ install:
 
 before_script:
   - sudo nginx -c t/nginx.conf -p "$PWD/"
+  - git clone https://github.com/fukamachi/fast-http ~/lisp/fast-http
+  - git clone https://github.com/fukamachi/quri ~/lisp/quri
+  - git clone https://github.com/fukamachi/cl-cookie ~/lisp/cl-cookie
+  - git clone https://github.com/fukamachi/dexador ~/lisp/dexador
+  - git clone https://github.com/fukamachi/http-body ~/lisp/http-body
 
 script:
   - "cl -l prove

--- a/clack-test.asd
+++ b/clack-test.asd
@@ -26,7 +26,7 @@
                :cl-syntax-annot
                :prove
                :flexi-streams
-               :drakma)
+               :dexador)
   :components ((:file "src/contrib/test")
                (:file "src/contrib/test/suite" :depends-on ("src/contrib/test")))
   :description "Testing Clack Applications.")

--- a/src/contrib/test/suite.lisp
+++ b/src/contrib/test/suite.lisp
@@ -39,6 +39,7 @@ Handler name is a keyword and doesn't include the clack.handler prefix.
 For example, if you have a handler `clack.handler.foo',
 you would call like this: `(run-server-tests :foo)'."
   (let ((*clack-test-handler* handler-name)
+        (dex:*use-connection-pool* nil)
         (*package* (find-package :clack.test.suite)))
     #+thread-support
     (if name

--- a/src/contrib/test/suite.lisp
+++ b/src/contrib/test/suite.lisp
@@ -486,7 +486,7 @@ you would call like this: `(run-server-tests :foo)'."
         (dex:get (localhost))
       (is status 200)
       (is (gethash "client-transfer-encoding" headers) nil)
-      (is body ""))))
+      (is body #() :test #'equalp))))
 
 (define-app-test |handle Authorization header|
   (lambda (env)

--- a/src/core/handler/fcgi.lisp
+++ b/src/core/handler/fcgi.lisp
@@ -96,7 +96,9 @@
       (fcgx-puts req (format nil "Status: ~D ~A~%" status (http-status-reason status)))
       (loop for (k v) on headers by #'cddr
             with hash = (make-hash-table :test #'eq)
-            if (gethash k hash)
+            if (eq k :set-cookie)
+              do (fcgx-puts req (format nil "~:(~A~): ~A~%" k v))
+            else if (gethash k hash)
               do (setf (gethash k hash)
                        (concatenate 'string (gethash k hash) ", " v))
             else

--- a/src/core/request.lisp
+++ b/src/core/request.lisp
@@ -171,7 +171,7 @@ Typically this will be something like :HTTP/1.0 or :HTTP/1.1.")
   (unless (slot-boundp this 'body-parameters)
     (setf (slot-value this 'body-parameters)
           (and (raw-body this)
-               (parse (content-type this) (raw-body this))))))
+               (parse (content-type this) (content-length this) (raw-body this))))))
 
 @export
 (defun shared-raw-body (env)


### PR DESCRIPTION
Clack handlers concatenate header values if there's the same header field even for Set-Cookie header.

However, Set-Cookie header contains "," in the value and cannot be concatenated in a single header. (e.g. `Set-Cookie: lu=Rg3vHJZnehYLjVg7qi3bZjzg; Expires=Tue, 15-Jan-2013 21:47:38 GMT; Path=/; Domain=.example.com; HttpOnly`)

This pull request fixes it by stopping the concatenation and adds a test case to clack.test.suite. It seems Drakma can't handle multiple `Set-Cookie` headers either, so I replaced it by [Dexador](https://github.com/fukamachi/dexador).