### PR TITLE
make wookie:send-respose not to specify :close t.

### DIFF
--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -154,11 +154,9 @@
                                   (car body)
                                   (with-fast-output (buffer :vector)
                                     (dolist (str body)
-                                      (fast-write-sequence (babel:string-to-octets str) buffer))))
-                        :close t))
+                                      (fast-write-sequence (babel:string-to-octets str) buffer))))))
         ((vector (unsigned-byte 8))
          (send-response res
                         :status status
                         :headers headers
-                        :body body
-                        :close t))))))
+                        :body body))))))


### PR DESCRIPTION
http://wookie.lyonbros.com/docs/request-handling#send-response
It shows 

> :close is used to tell Wookie to close the connection (or keep it open) after the response is sent. ... feel free to leave this blank unless you have a good reason not to.  

.

ref #108 