### PR TITLE
Fix a simple-file-error in clack.middleware.static (v1-compat). (#111)

### DIFF
--- a/v1-compat/src/core/app/file.lisp
+++ b/v1-compat/src/core/app/file.lisp
@@ -62,7 +62,11 @@
 @export
 (defgeneric should-handle (app file)
   (:method ((this <clack-app-file>) file)
-    (and (file-exists-p file)
+    (and (ignore-errors
+          ;; Ignore simple-file-error in a case that
+          ;; the file path contains some special characters like "?".
+          ;; See https://github.com/fukamachi/clack/issues/111
+          (file-exists-p file))
          (not (directory-exists-p file)))))
 
 @export


### PR DESCRIPTION
This is the same changes to https://github.com/fukamachi/lack/pull/5 for v1-compat.