### PR TITLE
Don't return a value from the response handler.

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -150,7 +150,8 @@ before passing to Hunchentoot."
                     (finish-output out)))))))
       (etypecase res
         (list (handle-normal-response res))
-        (function (funcall res #'handle-normal-response))))))
+        (function (funcall res #'handle-normal-response)))
+      (values))))
 
 (defun handle-request (req &key ssl)
   "Convert Request from server into a plist


### PR DESCRIPTION
When the clack app uses a delayed response and returns a NIL body,
HANDLE-RESPONSE has not called SEND-HEADERS, so hunchentoot expects the
return value of the handler to be the body of the response. As it is,
the handler is returning the value of the delayed response function,
which is usually not something we want sent. Instead, make sure the
handler never returns a value, since HANDLE-NORMAL-RESPONSE should
always be taking care of that.
