### PR TITLE
Make sure we send status and headers even with no body.

### DIFF
--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -138,7 +138,8 @@
                 (finish-response res))))))
 
       (etypecase body
-        (null) ;; nothing to response
+        ;; Just send the headers and status.
+        (null (send-response res :status status :headers headers))
         (pathname
          (let ((stream (start-response res
                                        :status status


### PR DESCRIPTION
Unlike the hunchentoot handler, we haven't set response headers before we
process the body, so we need to send a response even when there's no
body content.