### PR TITLE
Added force-output for hunchentoot streaming

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -135,8 +135,9 @@ before passing to Hunchentoot."
                                                    :external-format *hunchentoot-default-external-format*)
                             body)
                         out)
-                       (when close
-                         (finish-output out))))))
+                       (if close
+                           (finish-output out)
+                           (force-output out))))))
 
                (etypecase body
                  (null) ;; nothing to response


### PR DESCRIPTION
Currently hunchentoot streaming will not flush output untill ```:close t```. Fix it by forcing output.