### PR TITLE
Specify an empty body for NIL bodies.

### DIFF
--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -146,7 +146,7 @@
 
       (etypecase body
         ;; Just send the headers and status.
-        (null (send-response res :status status :headers headers))
+        (null (send-response res :status status :headers headers :body nil))
         (pathname
          (let ((stream (start-response res
                                        :status status


### PR DESCRIPTION
Wookie's docs for SEND-RESPONSE specify that it sets
Content-Length if the :body argument is specified, so we should
pass it for explicitly supplied bodies that are NIL. Without
it, Content-Length won't be set and the browser will hang
waiting for the connection to close.

Note: I just got a PR merged for wookie to fix another issue with NIL
bodies in wookie that causes the same behavior, so if you're going
to test you'll want to pull the latest wookie tip.