### PR TITLE
fix for lispworks case

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -126,7 +126,13 @@
                (bt:join-thread (hunchentoot::acceptor-process taskmaster))))
         (hunchentoot:stop acceptor))
       #+lispworks
-      (hunchentoot:start acceptor))))
+      (unwind-protect
+          (if threadedp
+              (progn
+                (hunchentoot:start acceptor)
+                (loop (sleep (expt 2 32))))
+              (hunchentoot:start acceptor))
+        (hunchentoot:stop acceptor)))))
 
 (defun handle-response (res)
   "Convert Response from Clack application into a string

--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -118,20 +118,14 @@
     (let* ((taskmaster (acceptor-taskmaster acceptor))
            (threadedp (typep taskmaster 'multi-threaded-taskmaster)))
       (setf (taskmaster-acceptor taskmaster) acceptor)
-      #-lispworks
       (unwind-protect
-           (progn
-             (hunchentoot:start acceptor)
-             (when threadedp
-               (bt:join-thread (hunchentoot::acceptor-process taskmaster))))
-        (hunchentoot:stop acceptor))
-      #+lispworks
-      (unwind-protect
-          (if threadedp
-              (progn
-                (hunchentoot:start acceptor)
-                (loop (sleep (expt 2 32))))
-              (hunchentoot:start acceptor))
+          (progn
+            (hunchentoot:start acceptor)
+            #-lispworks
+            (when threadedp
+              (bt:join-thread (hunchentoot::acceptor-process taskmaster)))
+            #+lispworks
+            (loop (sleep (expt 2 32))))
         (hunchentoot:stop acceptor)))))
 
 (defun handle-response (res)


### PR DESCRIPTION
lispworksの場合はhunchentoot::acceptor-processがすぐに終了するので
unwind-protectのprotected-formでstopさせると、clackupを呼び出すと同時にstopしてしまいます。

hunchentoot:start内で呼び出されているexecute-acceptorにあるaccept-connectionsが原因です。
https://github.com/edicl/hunchentoot/blob/9b9a760497ce874f23aa0be13eb6800692dc4b47/acceptor.lisp#L251