### PR TITLE
Don't immediately stop Hunchentoot under LispWorks

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -71,7 +71,8 @@
              '(500 () ("Internal Server Error"))))))))
 
 (defmethod hunchentoot:process-connection :around ((acceptor clack-acceptor) socket)
-  (let ((flex:*substitution-char* #-abcl #\Replacement_Character
+  (let ((flex:*substitution-char* #-(or abcl lispworks) #\Replacement_Character
+                                  #+lispworks #\Replacement-Character
                                   #+abcl #\?)
         (*client-socket* socket))
     (call-next-method)))
@@ -122,6 +123,7 @@
              (hunchentoot:start acceptor)
              (when threadedp
                (bt:join-thread (hunchentoot::acceptor-process taskmaster))))
+        #-lispworks
         (hunchentoot:stop acceptor)))))
 
 (defun handle-response (res)


### PR DESCRIPTION
This is an approach to getting Clack to work under LispWorks, that addresses issue #125.

It also includes the replacement character change from here https://github.com/fukamachi/clack/issues/125#issuecomment-317677213

Tested under LispWorks 7.1. 64-bit on macOS Sierra.