### PR TITLE
hunchentoot: lift up handler-case in acceptor-dispatch-request

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -62,13 +62,12 @@
   (let ((app (acceptor-app acceptor))
         (env (acceptor-handle-request acceptor req))
         (hunchentoot:*catch-errors-p* nil))
-    (handle-response
-     (if (acceptor-debug acceptor)
-         (funcall app env)
-         (handler-case (funcall app env)
-           (error (error)
-             (princ error *error-output*)
-             '(500 () ("Internal Server Error"))))))))
+    (if (acceptor-debug acceptor)
+        (handle-response (funcall app env))
+        (handler-case (handle-response (funcall app env))
+          (error (error)
+            (princ error *error-output*)
+            '(500 () ("Internal Server Error")))))))
 
 (defmethod hunchentoot:process-connection :around ((acceptor clack-acceptor) socket)
   (let ((flex:*substitution-char* #-(or abcl lispworks) #\Replacement_Character


### PR DESCRIPTION
Method binds hunchentoot:*catch-errors-p* to NIL, so hunchentoot tries to invoke
a debugger if a condition comes to it. Error condition wasn't handled by clack
if it happened in handle-response, because handler-case was wrapped around
funcall, not the whole expression.

HANDLE-RESPONSE might have raisen an exception from SSL library (and other
communication methods) for instance when peer has closed the connection - that
lead to uncought closed stream error condition. Fixes #127.