### PR TITLE
Fix conditional build

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -55,6 +55,7 @@
 (defgeneric acceptor-handle-request (acceptor req)
   (:method ((acceptor clack-acceptor) req)
     (handle-request req :ssl nil))
+  #-hunchentoot-no-ssl
   (:method  ((acceptor clack-ssl-acceptor) req)
     (handle-request req :ssl t)))
 


### PR DESCRIPTION
clack-ssl-acceptor only exists with ```#-hunchentoot-no-ssl``` condition.