### PR TITLE
Added a test to check if the server is respecting X-Forwarded-Proto header to set the scheme in the env

### DIFF
--- a/src/test/suite.lisp
+++ b/src/test/suite.lisp
@@ -160,6 +160,17 @@ you would call like this: `(run-server-tests :foo)'."
       (is (get-header headers :content-type) "text/plain; charset=utf-8")
       (is body "http")))
 
+  (subtest-app "url-scheme should respect X-Forwarded-Proto header"
+      (lambda (env)
+        `(200
+          (:content-type "text/plain; charset=utf-8")
+          (,(getf env :url-scheme))))
+    (multiple-value-bind (body status headers)
+        (dex:post (localhost) :headers '(("X-Forwarded-Proto" . "https")))
+      (is status 200)
+      (is (get-header headers :content-type) "text/plain; charset=utf-8")
+      (is body "https")))
+
   (subtest-app "return pathname"
       (lambda (env)
         (declare (ignore env))


### PR DESCRIPTION
The `X-Forwarded-Proto` header is a de-facto standard header for identifying the protocol (HTTP or HTTPS) that a client used to connect to your proxy or load balancer.

More details on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto

Pull https://github.com/fukamachi/woo/pull/79 depends on a test from this pull.