### PR TITLE
Make fastcgi secure by default

### DIFF
--- a/src/handler/fcgi.lisp
+++ b/src/handler/fcgi.lisp
@@ -34,7 +34,7 @@
 (defmethod initialize-instance :after ((acceptor <fcgi-acceptor>) &rest args)
   (declare (ignore args))
   (unless (acceptor-file-descriptor acceptor)
-    (let ((socket (usocket:socket-listen "0.0.0.0"
+    (let ((socket (usocket:socket-listen "127.0.0.1"
                                          (acceptor-port acceptor)
                                          :reuse-address t
                                          :backlog 128)))


### PR DESCRIPTION
If running the code on a server it's important that this port is not accessible to the world as it could be used to spoof requests. I also think there is no reason to leave it open for everybody.