### PR TITLE
Add restart for debugging

### DIFF
--- a/src/handler/fcgi.lisp
+++ b/src/handler/fcgi.lisp
@@ -49,7 +49,7 @@
            (let* ((env (handle-request req))
                   (res (if debug
                            (restart-case
-                             (funcall app env)
+                               (funcall app env)
                              (throw-internal-server-error ()
                                '(500 () ("Internal Server Error"))))
                            (handler-case (funcall app env)

--- a/src/handler/fcgi.lisp
+++ b/src/handler/fcgi.lisp
@@ -48,7 +48,10 @@
   (flet ((main-loop (req)
            (let* ((env (handle-request req))
                   (res (if debug
-                           (funcall app env)
+                           (restart-case
+                             (funcall app env)
+                             (throw-internal-server-error ()
+                               '(500 () ("Internal Server Error"))))
                            (handler-case (funcall app env)
                              (error (error)
                                (princ error *error-output*)

--- a/src/handler/toot.lisp
+++ b/src/handler/toot.lisp
@@ -39,7 +39,10 @@
                                        (handle-response
                                         req
                                         (if debug
-                                            (funcall app env)
+					    (restart-case
+						(funcall app env)
+					      (throw-internal-server-error ()
+						'(500 () ("Internal Server Error"))))
                                             (handler-case (funcall app env)
                                               (error (error)
                                                 (princ error *error-output*)

--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -68,7 +68,10 @@
         (handle-response
          res
          (if debug
-             (funcall app env)
+	     (restart-case
+		 (funcall app env)
+	       (throw-internal-server-error ()
+		 '(500 nil ("Internal Server Error"))))
              (handler-case (funcall app env)
                (error (error)
                  (princ error *error-output*)


### PR DESCRIPTION
It is really annoying that the server stops if an error occurs while developing. So I thought this would be a good idea to prevent that. Maybe you have an even better idea?