### PR TITLE
Don't attempt to parse body when content-type is NIL

### DIFF
--- a/v1-compat/src/core/request.lisp
+++ b/v1-compat/src/core/request.lisp
@@ -181,7 +181,8 @@ on an original raw-body."
 
       (setf (getf env :raw-body) (slot-value req 'raw-body))
       ;; POST parameters
-      (unless (slot-boundp req 'body-parameters)
+      (unless (or (null (content-type req))
+                  (slot-boundp req 'body-parameters))
         (setf (slot-value req 'body-parameters)
               (parse (content-type req) (content-length req) (raw-body req)))
         (file-position (raw-body req) 0)


### PR DESCRIPTION
It seems that changes in upstream http-body library are breaking v1-compat, and, transitively, lucerne. This seems to fix the problem on that side. 

On the other hand I'm not sure if http-body itself should not do this check, but trying to limit the possible breakage here to only applications requiring v1-compat.

