### PR TITLE
Catch errors while processing a request

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -61,8 +61,7 @@
 
 (defmethod acceptor-dispatch-request ((acceptor clack-acceptor) req)
   (let ((app (acceptor-app acceptor))
-        (env (acceptor-handle-request acceptor req))
-        (hunchentoot:*catch-errors-p* nil))
+        (env (acceptor-handle-request acceptor req)))
     (if (acceptor-debug acceptor)
         (handle-response (funcall app env))
         (handler-case (handle-response (funcall app env))


### PR DESCRIPTION
If clack with hunchentoot is launched and errors while processing requests occur many times, the server always returns a 503 response only, which does'nt seems to be an expected behaviour. This PR fixes this issue.

The following is an example for reproducing the issue:

Server:
```shell
$ for i in {1..10000};do echo "foo" >> /tmp/foo; done
$ ros -s lack-middleware-static -s clack -e '(clack:clackup (lack.app.file:make-app :file "/tmp/foo") :use-thread nil)'
```

Client:
```
CL-USER> (ql:quickload '(:usocket :bordeaux-threads))
CL-USER> (mapcar #'bt:join-thread
                 (loop repeat 300 collect (bt:make-thread
                                           (lambda () ;; the broken pipe error occurs
                                             (usocket:with-client-socket (a b "localhost" 5000)
                                               (write-sequence (format nil "GET / HTTP/1.1~A~A~A~A" #\Return #\Linefeed #\Return #\Linefeed) b)
                                               (force-output b))))))
```

The issue is because the current hunchentoot handler doesn't catch errors while processing a request, but invoke the debugger, which makes the thread stop. The thread is alive with the debugger being invoked. Many errors cause many threads and the server can't create anther thread for a new request.

`hunchentoot:*catch-errors-p*` is the variable whose value decides whether the debugger is invoked or not. The nil value invokes the debugger. While the `clack.handler.hunchentoot::initialize` method sets the variable to T, `clack.handler.hunchentoot::acceptor-dispatch-request` rebinds the variable to nil, which seems to be the root cause.