### PR TITLE
Resolve :address before start the web server. (fixes #165)

### DIFF
--- a/clack.asd
+++ b/clack.asd
@@ -25,6 +25,7 @@
                :lack-middleware-backtrace
                :lack-util
                :bordeaux-threads
+               :usocket
                :alexandria
                :uiop)
   :components ((:module "src"

--- a/src/handler.lisp
+++ b/src/handler.lisp
@@ -8,6 +8,7 @@
                 :make-thread
                 :thread-alive-p
                 :destroy-thread)
+  (:import-from :usocket)
   (:export :run
            :stop))
 (in-package :clack.handler)
@@ -16,7 +17,7 @@
   server
   acceptor)
 
-(defun run (app server &rest args &key use-thread &allow-other-keys)
+(defun run (app server &rest args &key (address nil address-specified-p) use-thread &allow-other-keys)
   (let ((handler-package (find-handler server))
         (bt:*default-special-bindings* `((*standard-output* . ,*standard-output*)
                                          (*error-output* . ,*error-output*)
@@ -25,7 +26,12 @@
              (apply (intern #.(string '#:run) handler-package)
                     app
                     :allow-other-keys t
-                    args)))
+                    (append
+                      (and address-specified-p
+                           (list :address
+                                 (usocket:vector-quad-to-dotted-quad
+                                   (usocket:get-host-by-name address))))
+                      args))))
       (make-handler
        :server server
        :acceptor (if use-thread

--- a/src/handler.lisp
+++ b/src/handler.lisp
@@ -29,7 +29,7 @@
                     (append
                       (and address-specified-p
                            (list :address
-                                 (usocket:vector-quad-to-dotted-quad
+                                 (usocket:host-to-hostname
                                    (usocket:get-host-by-name address))))
                       args))))
       (make-handler


### PR DESCRIPTION
"localhost" won't be accepted by some web servers like wookie.
This adds usocket as a dependency.