### PR TITLE
wookie: Fix POST handling

### DIFF
--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -114,7 +114,7 @@
             :url-scheme (if ssl "https" "http")
             :request-uri (request-resource req)
             :raw-body (flex:make-in-memory-input-stream (wookie:request-body req))
-            :content-length (gethash "content-length" headers)
+            :content-length (parse-integer (gethash "content-length" headers))
             :content-type (gethash "content-type" headers)
             :clack.streaming t
             :clack.nonblocking t


### PR DESCRIPTION
POSTing data without this patch results in `http-body.util:slurp-stream` calling `make-array` with a string `dimensions` argument, which it responds to with a very cryptic warning:
```
   The value
     "464"
   is not of type
     (OR LIST (MOD 4611686018427387901))
   when binding SB-VM::DIMENSIONS
```
and results in a 400 Bad Request.