### PR TITLE
wookie: Fix GET handling

### DIFF
--- a/src/handler/wookie.lisp
+++ b/src/handler/wookie.lisp
@@ -93,9 +93,10 @@
       (as:socket-closed () nil))))
 
 (defun handle-request (req &key ssl)
-  (let ((quri (request-uri req))
-        (http-version (http-version (request-http req)))
-        (headers (request-headers req)))
+  (let* ((quri (request-uri req))
+         (http-version (http-version (request-http req)))
+         (headers (request-headers req))
+         (content-length (gethash "content-length" headers)))
 
     (destructuring-bind (server-name &optional server-port)
         (split-sequence #\: (gethash "host" headers "") :from-end t :count 2)
@@ -114,7 +115,8 @@
             :url-scheme (if ssl "https" "http")
             :request-uri (request-resource req)
             :raw-body (flex:make-in-memory-input-stream (wookie:request-body req))
-            :content-length (parse-integer (gethash "content-length" headers))
+            :content-length (when content-length
+                              (parse-integer content-length :junk-allowed t))
             :content-type (gethash "content-type" headers)
             :clack.streaming t
             :clack.nonblocking t


### PR DESCRIPTION
Sorry for the disturbance - I managed to break requests without a Content-Length in #181 .
I could swear GET requests were working, but it was probably my stale environment.

All tests are now passing, apart from "test 404" which hangs regardless of my patches on all handlers - opening a separate issue for that.