### PR TITLE
Qualify Hunchentoot symbols and remove :use

### DIFF
--- a/src/handler/hunchentoot.lisp
+++ b/src/handler/hunchentoot.lisp
@@ -48,7 +48,7 @@
           :accessor acceptor-debug)))
 
 #-hunchentoot-no-ssl
-(defclass clack-ssl-acceptor (clack-acceptor ssl-acceptor) ())
+(defclass clack-ssl-acceptor (clack-acceptor hunchentoot:ssl-acceptor) ())
 
 (defgeneric acceptor-handle-request (acceptor req)
   (:method ((acceptor clack-acceptor) req)


### PR DESCRIPTION
This makes the code more consistent in style and makes clear things like what function a method is specializing.
Further, `handle-request` is now clearly the local function rather than the one from hunchentoot by the same name
