### PR TITLE
Support :silent in run to suppress NOTICE about running in debug mode

### DIFF
--- a/src/clack.lisp
+++ b/src/clack.lisp
@@ -104,7 +104,7 @@
                    :port port
                    :debug debug
                    :use-thread use-thread
-                   (delete-from-plist args :server :port :debug :silent :use-thread))
+                   (delete-from-plist args :server :port :debug :use-thread))
           (when (and use-thread
                      (not silent))
             (format t "~&~:(~A~) server is started.~%Listening on ~A:~A.~%" server address port)))))))

--- a/src/handler.lisp
+++ b/src/handler.lisp
@@ -21,12 +21,14 @@
 (defun run (app server &rest args
                 &key (address nil address-specified-p) use-thread
                      (swank-interface "127.0.0.1") swank-port debug
+                     silent
                 &allow-other-keys)
   (let ((handler-package (find-handler server))
         (bt2:*default-special-bindings* `((*standard-output* . ,*standard-output*)
                                           (*error-output* . ,*error-output*)
                                           ,@bt2:*default-special-bindings*)))
-    (when debug
+    (when (and debug
+               (not silent))
       (format t "NOTICE: Running in debug mode. Debugger will be invoked on errors.
   Specify ':debug nil' to turn it off on remote environments."))
     (flet ((run-server ()


### PR DESCRIPTION
This PR makes it possible to not output:

```
NOTICE: Running in debug mode. Debugger will be invoked on errors.
```

in case if `clackup` was called with `:debug t :silent t` arguments.