### PR TITLE
Make Swank an optional dependency

### DIFF
--- a/clack.asd
+++ b/clack.asd
@@ -7,7 +7,6 @@
                "lack-util"
                "bordeaux-threads"
                "usocket"
-               "swank"
                "alexandria"
                "uiop")
   :components ((:module "src"

--- a/roswell/clackup.ros
+++ b/roswell/clackup.ros
@@ -156,6 +156,11 @@ Options:
     ;; Load files
     (mapc #'load (getf opt-args :load))
 
+    ;; Load Swank if --swank-port is specified and not already loaded
+    (when (getf key-args :swank-port)
+      (unless (find-package :swank)
+        (ql:quickload :swank :silent t)))
+
     ;; Add :port and :fd from Server::Starter's environment var.
     (multiple-value-bind (port fd)
         (parse-server-starter-port)

--- a/src/handler.lisp
+++ b/src/handler.lisp
@@ -22,6 +22,7 @@
                 &key (address nil address-specified-p) use-thread
                      (swank-interface "127.0.0.1") swank-port debug
                 &allow-other-keys)
+  (declare (ignorable swank-interface))
   (let ((handler-package (find-handler server))
         (bt2:*default-special-bindings* `((*standard-output* . ,*standard-output*)
                                           (*error-output* . ,*error-output*)
@@ -31,7 +32,10 @@
   Specify ':debug nil' to turn it off on remote environments."))
     (flet ((run-server ()
              (when swank-port
-               (swank:create-server :interface swank-interface :port swank-port :dont-close t))
+               #+swank
+               (swank:create-server :interface swank-interface :port swank-port :dont-close t)
+               #-swank
+               (error "Swank is required to use :swank-port but is not loaded. Load SLIME or Swank first."))
              (apply (intern #.(string '#:run) handler-package)
                     app
                     :allow-other-keys t
@@ -63,5 +67,6 @@
         (let ((package (find-handler (handler-server handler))))
           (funcall (intern #.(string '#:stop) package) acceptor)))
     (when swank-port
+      #+swank
       (swank:stop-server swank-port))
     t))


### PR DESCRIPTION
Remove `swank` from `:depends-on` and guard Swank API calls with `#+swank` reader conditionals.

Loading Clack previously pulled in Swank unconditionally, which conflicts with SLIME's already-loaded version. The Swank integration (for `--swank-port`) now works only when Swank is already available in the image.

Fixes #195